### PR TITLE
Use spin() instead of spin_once(), because only spin() executes callb…

### DIFF
--- a/rqt_gui_cpp/src/rqt_gui_cpp/nodelet_plugin_provider.cpp
+++ b/rqt_gui_cpp/src/rqt_gui_cpp/nodelet_plugin_provider.cpp
@@ -48,8 +48,8 @@ NodeletPluginProvider::~NodeletPluginProvider()
 {
   if (ros_spin_thread_ != 0)
   {
-    ros_spin_thread_->abort = true;
     ros_spin_thread_->exec_.remove_node(node_);
+    ros_spin_thread_->exec_.cancel();
     ros_spin_thread_->wait();
     ros_spin_thread_->deleteLater();
     ros_spin_thread_ = 0;
@@ -134,7 +134,6 @@ void NodeletPluginProvider::init_plugin(const QString& plugin_id, qt_gui_cpp::Pl
 
 NodeletPluginProvider::RosSpinThread::RosSpinThread(QObject* parent)
   : QThread(parent)
-  , abort(false)
 {}
 
 NodeletPluginProvider::RosSpinThread::~RosSpinThread()
@@ -142,11 +141,8 @@ NodeletPluginProvider::RosSpinThread::~RosSpinThread()
 
 void NodeletPluginProvider::RosSpinThread::run()
 {
-  while (!abort)
-  {
-    // Spin the executor
-    exec_.spin_once();
-  }
+  // Spin the executor
+  exec_.spin();
 }
 
 

--- a/rqt_gui_cpp/src/rqt_gui_cpp/nodelet_plugin_provider.h
+++ b/rqt_gui_cpp/src/rqt_gui_cpp/nodelet_plugin_provider.h
@@ -86,7 +86,6 @@ protected:
     RosSpinThread(QObject* parent = 0);
     virtual ~RosSpinThread();
     void run();
-    bool abort;
     // Create an executor that will be responsible for execution of callbacks for a set of nodes.
     // With this version, all callbacks will be called from within this thread (the main one).
     rclcpp::executors::MultiThreadedExecutor exec_;


### PR DESCRIPTION
…acks multithreaded.